### PR TITLE
Fixed slide using fn navnv(): must not return

### DIFF
--- a/fosdem2019/fosdem.bas
+++ b/fosdem2019/fosdem.bas
@@ -301,9 +301,11 @@ while fn navnb()=0 and count < 5
 wend
 sound 2,3,10,400
 
+do
 while fn navnb()<256
   call motion
 wend
+loop
 
 return
 


### PR DESCRIPTION
without this, pressing any other key but left and right arrows will abort in gosub slide*1000 because slide has been polluted through ret(0) from navnb() (it is inkey() instead of a valid slide number)